### PR TITLE
Add base clang profile for desktop builds

### DIFF
--- a/conanfiles/profile/base/clang_compiler
+++ b/conanfiles/profile/base/clang_compiler
@@ -1,0 +1,7 @@
+[buildenv]
+CC=clang-20
+CXX=clang++-20
+
+[settings]
+compiler=clang
+compiler.version=20

--- a/conanfiles/profile/desktop_dev
+++ b/conanfiles/profile/desktop_dev
@@ -1,11 +1,7 @@
-[buildenv]
-CC=clang-20
-CXX=clang++-20
+include(base/clang_compiler)
 
 [settings]
 os=Linux
 arch=x86_64
-compiler=clang
-compiler.version=20
 compiler.libcxx=libstdc++11
 build_type=Debug

--- a/conanfiles/profile/desktop_release
+++ b/conanfiles/profile/desktop_release
@@ -1,11 +1,7 @@
-[buildenv]
-CC=clang-20
-CXX=clang++-20
+include(base/clang_compiler)
 
 [settings]
 os=Linux
 arch=x86_64
-compiler=clang
-compiler.version=20
 compiler.libcxx=libstdc++11
 build_type=Release


### PR DESCRIPTION
## Summary
- create `base/clang_compiler` profile with clang-20 settings
- deduplicate desktop profiles by including the base profile

## Testing
- `python3 project.py --deps-install --preset desktop_dev` *(fails: conan: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405f7790708323ada76a9acbc14699