### PR TITLE
Adjust libcxx setting location

### DIFF
--- a/conanfiles/profile/base/clang_compiler
+++ b/conanfiles/profile/base/clang_compiler
@@ -5,3 +5,4 @@ CXX=clang++-20
 [settings]
 compiler=clang
 compiler.version=20
+compiler.libcxx=libstdc++11

--- a/conanfiles/profile/desktop_dev
+++ b/conanfiles/profile/desktop_dev
@@ -3,5 +3,4 @@ include(base/clang_compiler)
 [settings]
 os=Linux
 arch=x86_64
-compiler.libcxx=libstdc++11
 build_type=Debug

--- a/conanfiles/profile/desktop_release
+++ b/conanfiles/profile/desktop_release
@@ -3,5 +3,4 @@ include(base/clang_compiler)
 [settings]
 os=Linux
 arch=x86_64
-compiler.libcxx=libstdc++11
 build_type=Release


### PR DESCRIPTION
## Summary
- move `compiler.libcxx` from desktop profiles into `clang_compiler`

## Testing
- `./project.py --test` *(fails: QT_ROOT env variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_6840689d970883239e18a0afe19e3579