### PR TITLE
Fix wasm build dist output path

### DIFF
--- a/.github/workflows/AppBuild.yml
+++ b/.github/workflows/AppBuild.yml
@@ -127,7 +127,7 @@ jobs:
       if: matrix.build_profile == 'wasm_release' && github.ref == 'refs/heads/main' && github.event_name == 'push'
       uses: actions/upload-pages-artifact@v3
       with:
-        path: ${{github.workspace}}/build/wasm_release/dist
+        path: ${{github.workspace}}/dist/wasm_release
 
   deploy:
     needs: build

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 app/*
 build/*
+# CMake install results
+dist/
 TermGraph/*
 .qmake.stash
 Makefile

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,8 +256,9 @@ qt_add_qml_module (TermGraph
     QML_FILES "qml/Main.qml")
 
 if (WASM)
-    # The install folder is inside the build directory
-    set (CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/dist")
+    # The install folder is inside the project root and depends on build preset
+    get_filename_component(_build_preset "${CMAKE_BINARY_DIR}" NAME)
+    set (CMAKE_INSTALL_PREFIX "${CMAKE_SOURCE_DIR}/dist/${_build_preset}")
 
     # Install static resources
     install (FILES


### PR DESCRIPTION
## Summary
- install WASM artifacts to `dist/<preset>` under project root
- ignore new dist directory in version control
- update workflow to upload from new dist path

## Testing
- `./project.py --test --preset desktop_dev` *(fails: path at QT_ROOT env.variable not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68406830d9a88323947aa492eef3c56d