### PR TITLE
Add ccache in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
       with:
         key: ${{ runner.os }}-${{ matrix.build_profile }}-ccache
         create-symlink: true
+        verbose: 1
 
     - name: Run clang-format style check
       if: matrix.build_profile == 'wasm_release'
@@ -115,9 +116,6 @@ jobs:
 
     - name: Cmake build
       run: ./project.py --build --preset ${{ matrix.build_profile }}
-
-    - name: Show ccache statistics
-      run: ccache -s
 
     - name: CMake install
       run: ./project.py --cmake-install --preset ${{ matrix.build_profile }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ env:
   CONAN_VERSION: 2.16.1
   AQT_VERSION: ==3.2.0
   PY7ZR_VERSION: ==0.20.2
+  CCACHE_DIR: ${{ github.workspace }}/.ccache
+  CCACHE_MAXSIZE: 500M
+  CMAKE_C_COMPILER_LAUNCHER: ccache
+  CMAKE_CXX_COMPILER_LAUNCHER: ccache
 
 jobs:
   build:
@@ -40,6 +44,11 @@ jobs:
 
     - name: Install Clang-tools
       run: sudo apt install -y clang-tools-${{ env.CLANG_VERSION }}
+
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1
+      with:
+        key: ${{ runner.os }}-${{ matrix.build_profile }}-ccache
 
     - name: Run clang-format style check
       if: matrix.build_profile == 'wasm_release'
@@ -111,6 +120,9 @@ jobs:
     - name: CTest
       if: matrix.build_profile != 'wasm_release'
       run: ./project.py --test --preset ${{ matrix.build_profile }}
+
+    - name: Show ccache statistics
+      run: ccache -s
 
     # - name: Test Report
     #   if: matrix.build_profile != 'wasm_release' && (success() || failure())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ env:
   PY7ZR_VERSION: ==0.20.2
   CCACHE_DIR: ${{ github.workspace }}/.ccache
   CCACHE_MAXSIZE: 500M
+  CCACHE_BASEDIR: ${{ github.workspace }}
   CMAKE_C_COMPILER_LAUNCHER: ccache
   CMAKE_CXX_COMPILER_LAUNCHER: ccache
 
@@ -49,6 +50,7 @@ jobs:
       uses: hendrikmuhs/ccache-action@v1
       with:
         key: ${{ runner.os }}-${{ matrix.build_profile }}-ccache
+        create-symlink: true
 
     - name: Run clang-format style check
       if: matrix.build_profile == 'wasm_release'
@@ -114,15 +116,15 @@ jobs:
     - name: Cmake build
       run: ./project.py --build --preset ${{ matrix.build_profile }}
 
+    - name: Show ccache statistics
+      run: ccache -s
+
     - name: CMake install
       run: ./project.py --cmake-install --preset ${{ matrix.build_profile }}
 
     - name: CTest
       if: matrix.build_profile != 'wasm_release'
       run: ./project.py --test --preset ${{ matrix.build_profile }}
-
-    - name: Show ccache statistics
-      run: ccache -s
 
     # - name: Test Report
     #   if: matrix.build_profile != 'wasm_release' && (success() || failure())


### PR DESCRIPTION
## Summary
- speed up builds by enabling ccache

## Testing
- `pytest -q`
- `./project.py --test --preset desktop_dev` *(fails: path at QT_ROOT env.variable not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68600765f83c8323afba9d961b2ffe35