### PR TITLE
ci: clear clang module cache before wasm build to fix cache conflict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,12 +109,12 @@ jobs:
         echo "::notice file=,line=1,col=1::Conan version: $(conan --version)"
         echo "::notice file=,line=1,col=1::CMake version: $(cmake --version | head -n 1)"
 
+    - name: Conan install dependencies
+      run: ./project.py --deps-install --preset ${{ matrix.build_profile }}
+
     - name: Clear clang module cache for wasm build
       if: matrix.build_profile == 'wasm_release'
       run: rm -rf ~/.cache/clang
-
-    - name: Conan install dependencies
-      run: ./project.py --deps-install --preset ${{ matrix.build_profile }}
 
     - name: Cmake build
       run: ./project.py --build --preset ${{ matrix.build_profile }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,10 @@ jobs:
         echo "::notice file=,line=1,col=1::Conan version: $(conan --version)"
         echo "::notice file=,line=1,col=1::CMake version: $(cmake --version | head -n 1)"
 
+    - name: Clear clang module cache for wasm build
+      if: matrix.build_profile == 'wasm_release'
+      run: rm -rf ~/.cache/clang
+
     - name: Conan install dependencies
       run: ./project.py --deps-install --preset ${{ matrix.build_profile }}
 


### PR DESCRIPTION
System clang-21 and emscripten's internal clang share the same
~/.cache/clang/ModuleCache directory. This causes a fatal error where
_Builtin_stddef and other builtin modules appear as defined twice.

Clearing the module cache before conan/cmake steps ensures emscripten's
clang starts with a clean slate and doesn't conflict with system clang
entries.

https://claude.ai/code/session_015ZiJW11t5hkiAjSRBi3NNo