### PR TITLE
Update ccache-action to v1.2.23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-${{ env.CLANG_VERSION }} 100
 
     - name: Setup ccache
-      uses: hendrikmuhs/ccache-action@v1
+      uses: hendrikmuhs/ccache-action@v1.2.23
       with:
         key: ${{ runner.os }}-${{ matrix.build_profile }}-ccache
         create-symlink: true


### PR DESCRIPTION
## Summary
Updates the `hendrikmuhs/ccache-action` GitHub Action to a specific pinned version for improved reproducibility and stability in CI workflows.

## Changes
- Pin `hendrikmuhs/ccache-action` from `v1` (floating tag) to `v1.2.23` (specific release version)

## Details
This change replaces the floating `v1` tag with an explicit version pin (`v1.2.23`). Using specific versions for GitHub Actions provides:
- **Reproducibility**: Ensures consistent behavior across CI runs
- **Stability**: Prevents unexpected breaking changes from automatic updates
- **Auditability**: Makes it clear which version of the action is being used

https://claude.ai/code/session_01JHFREyPTcSfguRFvzNap2U